### PR TITLE
Pruned Visualizer

### DIFF
--- a/prosperity4/__main__.py
+++ b/prosperity4/__main__.py
@@ -14,6 +14,7 @@ from prosperity4.file_reader import FileReader, FileSystemReader, PackageResourc
 from prosperity4.models import BacktestResult, TradeMatchingMode
 from prosperity4.open import open_visualizer
 from prosperity4.runner import run_backtest
+from prosperity4.prune_log import prune_log
 import json
 
 DIST_NAME = "prosperity4"
@@ -245,6 +246,7 @@ def cli(
     version: Annotated[bool, Option("--version", "-v", help="Show the program's version number and exit.", is_eager=True, callback=version_callback)] = False,
     grid_search: Annotated[bool, Option("--grid-search", help="Run the backtester in grid search mode. NOTE: MUST PROVIDE --param-file arg.")] = False,
     param_file: Annotated[Optional[Path], Option("--param-file", help="Path to the grid search parameter file.", show_default=False, exists=True, file_okay=True, dir_okay=False, resolve_path=True)] = None,
+    no_prune: Annotated[bool, Option("--no-prune", help="Do not prune the output log before opening it in the visualizer.")] = False,
 ) -> None:  # fmt: skip
     
     if out is not None and no_out:
@@ -386,6 +388,8 @@ def cli(
             write_output_json(output_file, merged_results)
 
     if vis and output_file is not None:
+        if not no_prune and not csv:
+            output_file = prune_log(output_file)
         open_visualizer(output_file)
 
 

--- a/prosperity4/prune_log.py
+++ b/prosperity4/prune_log.py
@@ -2,153 +2,163 @@ import json
 import sys
 import re
 from pathlib import Path
+from typing import Set
+import orjson
+
+def get_user_traded_products(input_path: Path) -> Set[str]:
+    """Finds products traded by SUBMISSION by reading from the end of the file."""
+    products = set()
+    with open(input_path, 'rb') as f:
+        # Seek toward the end of the file to find Trade History efficiently
+        f.seek(0, 2)
+        file_size = f.tell()
+        # Read the last 5MB, which should cover all trades for a typical day
+        seek_pos = max(0, file_size - 5 * 1024 * 1024)
+        f.seek(seek_pos)
+        chunk = f.read().decode('utf-8', errors='ignore')
+        
+        if "Trade History:" in chunk:
+            trades_section = chunk.split("Trade History:")[1].strip()
+            # Clean up non-standard JSON (trailing commas and potential single quotes from str() calls)
+            trades_json = re.sub(r',\s*([\]}])', r'\1', trades_section)
+            try:
+                trades_data = orjson.loads(trades_json)
+                for trade in trades_data:
+                    if trade.get("buyer") == "SUBMISSION" or trade.get("seller") == "SUBMISSION":
+                        products.add(trade.get("symbol"))
+            except Exception as e:
+                # Fallback to regex if JSON parsing fails on the chunk
+                matches = re.findall(r'"symbol":\s*"([^"]+)"', trades_section)
+                # This is a bit broad, so we check for SUBMISSION nearby
+                trade_blocks = re.findall(r'\{[^{}]*?SUBMISSION[^{}]*?\}', trades_section)
+                for block in trade_blocks:
+                    sym_match = re.search(r'"symbol":\s*"([^"]+)"', block)
+                    if sym_match:
+                        products.add(sym_match.group(1))
+    return products
+
+def prune_lambda_data(data, products):
+    """Recursively prunes the visualizer state data."""
+    if isinstance(data, list):
+        if len(data) > 0 and isinstance(data[0], list) and len(data[0]) == 3 and isinstance(data[0][0], str):
+            # Found listings: [[symbol, name, 1], ...]
+            return [x for x in data if x[0] in products]
+        return [prune_lambda_data(x, products) for x in data]
+    
+    if isinstance(data, dict):
+        return {k: prune_lambda_data(v, products) for k, v in data.items() 
+                if k in products or not isinstance(v, (dict, list))}
+    
+    if isinstance(data, str) and data:
+        # Prune log lines within lambdaLog
+        lines = data.split('\n')
+        return "\n".join([l for l in lines if any(p in l for p in products) or not l.strip()])
+        
+    return data
 
 def prune_log(input_path: Path) -> Path:
     output_path = input_path.with_name(f"{input_path.stem}-pruned{input_path.suffix}")
     
-    with open(input_path, 'r') as f:
-        lines = f.readlines()
-
-    # Find section indices
-    sandbox_start = -1
-    activities_start = -1
-    trades_start = -1
-
-    for i, line in enumerate(lines):
-        if line.strip() == "Sandbox logs:":
-            sandbox_start = i
-        elif line.strip() == "Activities log:":
-            activities_start = i
-        elif line.strip() == "Trade History:":
-            trades_start = i
-
-    if any(idx == -1 for idx in [sandbox_start, activities_start, trades_start]):
-        print("Could not find all sections in the log file.")
+    user_traded_products = get_user_traded_products(input_path)
+    if not user_traded_products:
+        print("No user trades found. Keeping all products.")
+        # We need a list of all products to avoid pruning everything
+        # For simplicity, if no trades, just return input_path or copy
         return input_path
-
-    # Extract sections
-    sandbox_lines = lines[sandbox_start:activities_start]
-    activities_lines = lines[activities_start:trades_start]
-    trades_lines = lines[trades_start:]
-
-    # Step 1: Identify user-traded products from Trade History
-    trades_json_str = "".join(trades_lines[1:]).strip()
-    
-    # Handle non-standard JSON with trailing commas
-    trades_json_str = re.sub(r',\s*([\]}])', r'\1', trades_json_str)
-    
-    try:
-        trades_data = json.loads(trades_json_str)
-    except json.JSONDecodeError as e:
-        print(f"Error decoding Trade History JSON: {e}")
-        return input_path
-
-    user_traded_products = set()
-    for trade in trades_data:
-        if trade.get("buyer") == "SUBMISSION" or trade.get("seller") == "SUBMISSION":
-            user_traded_products.add(trade.get("symbol"))
 
     print(f"User traded products: {user_traded_products}")
 
-    # Step 2: Prune Trade History
-    pruned_trades_data = [t for t in trades_data if t.get("symbol") in user_traded_products]
-    
-    # Step 3: Prune Sandbox Logs
-    def prune_lambda_data(data, products):
-        if isinstance(data, list):
-            # Check if it's a listing: [[symbol, name, 1], ...]
-            if len(data) > 0 and isinstance(data[0], list) and len(data[0]) == 3 and isinstance(data[0][2], int):
-                return [item for item in data if item[0] in products]
-            
-            # Recursively prune list items
-            return [prune_lambda_data(item, products) for item in data]
+    with open(input_path, 'r', encoding='utf-8') as fin, \
+         open(output_path, 'wb') as fout:
         
-        if isinstance(data, dict):
-            # Prune dictionary keys (Order Depths, Position, Market Trades)
-            return {k: prune_lambda_data(v, products) for k, v in data.items() if k in products or not isinstance(v, (dict, list))}
+        section = "header"
+        buffer = []
         
-        if isinstance(data, str):
-            # Prune log lines
-            log_lines = data.split('\n')
-            return "\n".join([line for line in log_lines if any(p in line for p in products) or not line.strip()])
+        for line in fin:
+            line_strip = line.strip()
             
-        return data
+            if line_strip == "Sandbox logs:":
+                section = "sandbox"
+                fout.write(line.encode('utf-8'))
+                continue
+            elif line_strip == "Activities log:":
+                section = "activities"
+                fout.write(line.encode('utf-8'))
+                continue
+            elif line_strip == "Trade History:":
+                section = "trades"
+                fout.write(line.encode('utf-8'))
+                break # We'll handle trades at the end
 
-    pruned_sandbox_lines = [sandbox_lines[0]] # "Sandbox logs:"
-    sandbox_content = "".join(sandbox_lines[1:])
-    
-    # Simple JSON object extractor that handles nested braces
-    def extract_json_objects(text):
-        objs = []
-        start = -1
-        depth = 0
-        for i, char in enumerate(text):
-            if char == '{':
-                if depth == 0:
-                    start = i
-                depth += 1
-            elif char == '}':
-                depth -= 1
-                if depth == 0 and start != -1:
-                    objs.append(text[start:i+1])
-                    start = -1
-        return objs
-
-    json_objects = extract_json_objects(sandbox_content)
-    
-    for obj_str in json_objects:
-        try:
-            obj = json.loads(obj_str)
-            
-            # Prune sandboxLog (limit warnings)
-            if obj.get("sandboxLog"):
-                sb_lines = obj["sandboxLog"].strip().split('\n')
-                obj["sandboxLog"] = "\n".join([line for line in sb_lines if any(p in line for p in user_traded_products)])
-
-            # Prune lambdaLog
-            if obj.get("lambdaLog"):
-                l_log = obj["lambdaLog"].strip()
-                if l_log.startswith("[["):
+            if section == "sandbox":
+                if line_strip == "{":
+                    buffer = [line]
+                elif line_strip == "}":
+                    buffer.append(line)
                     try:
-                        l_data = json.loads(l_log)
-                        l_data = prune_lambda_data(l_data, user_traded_products)
-                        obj["lambdaLog"] = json.dumps(l_data)
-                    except json.JSONDecodeError:
-                        log_lines = l_log.split('\n')
-                        obj["lambdaLog"] = "\n".join([line for line in log_lines if any(p in line for p in user_traded_products)])
+                        obj = orjson.loads("".join(buffer))
+                        
+                        # Prune sandboxLog
+                        if obj.get("sandboxLog"):
+                            sb_lines = obj["sandboxLog"].strip().split('\n')
+                            obj["sandboxLog"] = "\n".join([l for l in sb_lines if any(p in l for p in user_traded_products)])
+                        
+                        # Prune lambdaLog
+                        if obj.get("lambdaLog"):
+                            l_log = obj["lambdaLog"].strip()
+                            if l_log.startswith("[["):
+                                try:
+                                    l_data = orjson.loads(l_log)
+                                    l_data = prune_lambda_data(l_data, user_traded_products)
+                                    obj["lambdaLog"] = orjson.dumps(l_data).decode('utf-8')
+                                except:
+                                    pass # Keep original if parse fails
+                            else:
+                                lines = l_log.split('\n')
+                                obj["lambdaLog"] = "\n".join([l for l in lines if any(p in l for p in user_traded_products)])
+                        
+                        # Write pruned object (indent=2)
+                        fout.write(orjson.dumps(obj, option=orjson.OPT_INDENT_2))
+                        fout.write(b"\n")
+                    except:
+                        fout.write("".join(buffer).encode('utf-8'))
+                    buffer = []
+                elif buffer:
+                    buffer.append(line)
                 else:
-                    log_lines = l_log.split('\n')
-                    obj["lambdaLog"] = "\n".join([line for line in log_lines if any(p in line for p in user_traded_products)])
-            
-            pruned_sandbox_lines.append(json.dumps(obj, indent=2) + "\n")
-        except json.JSONDecodeError:
-            pruned_sandbox_lines.append(obj_str + "\n")
+                    fout.write(line.encode('utf-8'))
+                    
+            elif section == "activities":
+                parts = line_strip.split(';')
+                if len(parts) > 2:
+                    product = parts[2]
+                    # Index 2 is the product column. Header check:
+                    if product == "product" or product in user_traded_products:
+                        fout.write(line.encode('utf-8'))
+                else:
+                    fout.write(line.encode('utf-8'))
+            else:
+                fout.write(line.encode('utf-8'))
 
-    # Step 4: Prune Activities Log
-    pruned_activities_lines = [activities_lines[0], activities_lines[1]]
-    for line in activities_lines[2:]:
-        if not line.strip():
-            continue
-        parts = line.split(';')
-        if len(parts) > 2:
-            product = parts[2]
-            if product in user_traded_products:
-                pruned_activities_lines.append(line)
-
-    # Step 5: Reassemble and write
-    with open(output_path, 'w') as f:
-        for line in pruned_sandbox_lines:
-            f.write(line)
-        
-        if not pruned_sandbox_lines[-1].endswith('\n'):
-            f.write('\n')
-        for line in pruned_activities_lines:
-            f.write(line)
-        
-        f.write("\n\n\n\n\nTrade History:\n")
-        f.write("[\n")
-        f.write(",\n".join(json.dumps(t, indent=2).replace('\n', '\n  ') for t in pruned_trades_data))
-        f.write("\n]")
+        # Handle Trade History
+        if section == "trades":
+            fout.write(b"[\n")
+            # We already identified user_traded_products, but we need to write the actual trade rows
+            # Read from the end again to get the full list
+            with open(input_path, 'rb') as f:
+                f.seek(seek_pos if 'seek_pos' in locals() else 0)
+                chunk = f.read().decode('utf-8', errors='ignore')
+                if "Trade History:" in chunk:
+                    trades_json = re.sub(r',\s*([\]}])', r'\1', chunk.split("Trade History:")[1].strip())
+                    try:
+                        all_trades = orjson.loads(trades_json)
+                        pruned_trades = [t for t in all_trades if t.get("symbol") in user_traded_products]
+                        trade_lines = [orjson.dumps(t, option=orjson.OPT_INDENT_2).decode('utf-8').replace('\n', '\n  ') 
+                                       for t in pruned_trades]
+                        fout.write(",\n".join(trade_lines).encode('utf-8'))
+                    except:
+                        pass
+            fout.write(b"\n]")
 
     print(f"Pruned log saved to {output_path}")
     return output_path

--- a/prosperity4/prune_log.py
+++ b/prosperity4/prune_log.py
@@ -1,0 +1,166 @@
+import json
+import sys
+import re
+from pathlib import Path
+
+def prune_log(input_path: Path) -> Path:
+    output_path = input_path.with_name(f"{input_path.stem}-pruned{input_path.suffix}")
+    
+    with open(input_path, 'r') as f:
+        lines = f.readlines()
+
+    # Find section indices
+    sandbox_start = -1
+    activities_start = -1
+    trades_start = -1
+
+    for i, line in enumerate(lines):
+        if line.strip() == "Sandbox logs:":
+            sandbox_start = i
+        elif line.strip() == "Activities log:":
+            activities_start = i
+        elif line.strip() == "Trade History:":
+            trades_start = i
+
+    if any(idx == -1 for idx in [sandbox_start, activities_start, trades_start]):
+        print("Could not find all sections in the log file.")
+        return input_path
+
+    # Extract sections
+    sandbox_lines = lines[sandbox_start:activities_start]
+    activities_lines = lines[activities_start:trades_start]
+    trades_lines = lines[trades_start:]
+
+    # Step 1: Identify user-traded products from Trade History
+    trades_json_str = "".join(trades_lines[1:]).strip()
+    
+    # Handle non-standard JSON with trailing commas
+    trades_json_str = re.sub(r',\s*([\]}])', r'\1', trades_json_str)
+    
+    try:
+        trades_data = json.loads(trades_json_str)
+    except json.JSONDecodeError as e:
+        print(f"Error decoding Trade History JSON: {e}")
+        return input_path
+
+    user_traded_products = set()
+    for trade in trades_data:
+        if trade.get("buyer") == "SUBMISSION" or trade.get("seller") == "SUBMISSION":
+            user_traded_products.add(trade.get("symbol"))
+
+    print(f"User traded products: {user_traded_products}")
+
+    # Step 2: Prune Trade History
+    pruned_trades_data = [t for t in trades_data if t.get("symbol") in user_traded_products]
+    
+    # Step 3: Prune Sandbox Logs
+    def prune_lambda_data(data, products):
+        if isinstance(data, list):
+            # Check if it's a listing: [[symbol, name, 1], ...]
+            if len(data) > 0 and isinstance(data[0], list) and len(data[0]) == 3 and isinstance(data[0][2], int):
+                return [item for item in data if item[0] in products]
+            
+            # Recursively prune list items
+            return [prune_lambda_data(item, products) for item in data]
+        
+        if isinstance(data, dict):
+            # Prune dictionary keys (Order Depths, Position, Market Trades)
+            return {k: prune_lambda_data(v, products) for k, v in data.items() if k in products or not isinstance(v, (dict, list))}
+        
+        if isinstance(data, str):
+            # Prune log lines
+            log_lines = data.split('\n')
+            return "\n".join([line for line in log_lines if any(p in line for p in products) or not line.strip()])
+            
+        return data
+
+    pruned_sandbox_lines = [sandbox_lines[0]] # "Sandbox logs:"
+    sandbox_content = "".join(sandbox_lines[1:])
+    
+    # Simple JSON object extractor that handles nested braces
+    def extract_json_objects(text):
+        objs = []
+        start = -1
+        depth = 0
+        for i, char in enumerate(text):
+            if char == '{':
+                if depth == 0:
+                    start = i
+                depth += 1
+            elif char == '}':
+                depth -= 1
+                if depth == 0 and start != -1:
+                    objs.append(text[start:i+1])
+                    start = -1
+        return objs
+
+    json_objects = extract_json_objects(sandbox_content)
+    
+    for obj_str in json_objects:
+        try:
+            obj = json.loads(obj_str)
+            
+            # Prune sandboxLog (limit warnings)
+            if obj.get("sandboxLog"):
+                sb_lines = obj["sandboxLog"].strip().split('\n')
+                obj["sandboxLog"] = "\n".join([line for line in sb_lines if any(p in line for p in user_traded_products)])
+
+            # Prune lambdaLog
+            if obj.get("lambdaLog"):
+                l_log = obj["lambdaLog"].strip()
+                if l_log.startswith("[["):
+                    try:
+                        l_data = json.loads(l_log)
+                        l_data = prune_lambda_data(l_data, user_traded_products)
+                        obj["lambdaLog"] = json.dumps(l_data)
+                    except json.JSONDecodeError:
+                        log_lines = l_log.split('\n')
+                        obj["lambdaLog"] = "\n".join([line for line in log_lines if any(p in line for p in user_traded_products)])
+                else:
+                    log_lines = l_log.split('\n')
+                    obj["lambdaLog"] = "\n".join([line for line in log_lines if any(p in line for p in user_traded_products)])
+            
+            pruned_sandbox_lines.append(json.dumps(obj, indent=2) + "\n")
+        except json.JSONDecodeError:
+            pruned_sandbox_lines.append(obj_str + "\n")
+
+    # Step 4: Prune Activities Log
+    pruned_activities_lines = [activities_lines[0], activities_lines[1]]
+    for line in activities_lines[2:]:
+        if not line.strip():
+            continue
+        parts = line.split(';')
+        if len(parts) > 2:
+            product = parts[2]
+            if product in user_traded_products:
+                pruned_activities_lines.append(line)
+
+    # Step 5: Reassemble and write
+    with open(output_path, 'w') as f:
+        for line in pruned_sandbox_lines:
+            f.write(line)
+        
+        if not pruned_sandbox_lines[-1].endswith('\n'):
+            f.write('\n')
+        for line in pruned_activities_lines:
+            f.write(line)
+        
+        f.write("\n\n\n\n\nTrade History:\n")
+        f.write("[\n")
+        f.write(",\n".join(json.dumps(t, indent=2).replace('\n', '\n  ') for t in pruned_trades_data))
+        f.write("\n]")
+
+    print(f"Pruned log saved to {output_path}")
+    return output_path
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python prune_log.py <logfile>")
+        sys.exit(1)
+    
+    log_file = Path(sys.argv[1])
+    if not log_file.exists():
+        print(f"File {log_file} does not exist.")
+        sys.exit(1)
+        
+    prune_log(log_file)


### PR DESCRIPTION
- Adds a script which prunes out non-traded enities from the generated log file and redirects the visualizer to use the pruned log.
- The `--no-prune` flag is added to bt which will opt out of the pruning and should be equivalent to how the bt/vis would run prior to this merge

### Instructions

```
uv run bt trader.py 3 --vis
```
This will run the backtester and launch visualizer with the pruned logs

```
uv run bt trader.py 3 --vis --no-prune
```
Will run the backtester and launch visualizer with the full log output